### PR TITLE
Update broken source links

### DIFF
--- a/docs/_docs/examples.md
+++ b/docs/_docs/examples.md
@@ -14,43 +14,43 @@ title: "Examples"
 {:toc}
 
 ---
-Examples have been provided that show how to control the JavaScript engine and how  to implement scriptable host objects. All the examples are in the git tree at [mozilla/js/rhino/examples](https://github.com/mozilla/rhino/tree/master/examples/).
+Examples have been provided that show how to control the JavaScript engine and how  to implement scriptable host objects. All the examples are in the git tree at [examples/src/main](https://github.com/mozilla/rhino/tree/master/examples/src/main/).
 
 ## Sample Scripts
 
-The [unique.js](https://github.com/mozilla/rhino/tree/master/examples/unique.js) script allows printing unique lines from a file.
+The [unique.js](https://github.com/mozilla/rhino/blob/master/examples/src/main/resources/unique.js) script allows printing unique lines from a file.
 
-The [liveConnect.js](https://github.com/mozilla/rhino/tree/master/examples/liveConnect.js) script shows a sample usage of LiveConnect (Java-to-JavaScript connectivity).
+The [liveConnect.js](https://github.com/mozilla/rhino/blob/master/examples/src/main/resources/liveConnect.js) script shows a sample usage of LiveConnect (Java-to-JavaScript connectivity).
 
-The [jsdoc.js](https://github.com/mozilla/rhino/tree/master/examples/jsdoc.js) script is a JavaScript analog to Java's `javadoc`. It makes heavy use of regular expressions.
+The [jsdoc.js](https://github.com/mozilla/rhino/blob/master/examples/src/main/resources/jsdoc.js) script is a JavaScript analog to Java's `javadoc`. It makes heavy use of regular expressions.
 
-The [checkParam.js](https://github.com/mozilla/rhino/tree/master/examples/checkParam.js) script is a useful tool to check that `@param` tags in Java documentation comments match the parameters in the corresponding Java method.
+The [checkParam.js](https://github.com/mozilla/rhino/blob/master/examples/src/main/resources/checkParam.js) script is a useful tool to check that `@param` tags in Java documentation comments match the parameters in the corresponding Java method.
 
-The [enum.js](https://github.com/mozilla/rhino/tree/master/examples/enum.js) script is a good example of using a JavaAdapter to implement a Java interface using a JavaScript object.
+The [enum.js](https://github.com/mozilla/rhino/blob/master/examples/src/main/resources/enum.js) script is a good example of using a JavaAdapter to implement a Java interface using a JavaScript object.
 
-The [NervousText.js](https://github.com/mozilla/rhino/tree/master/examples/NervousText.js) script is a JavaScript implementation of the famous NervousText applet using JavaScript compiled to Java classes using [jsc](../_tools/javascript_compiler.md). It can be run in the HTML page [NervousText.html](https://github.com/mozilla/rhino/tree/master/examples/NervousText.html).
+The [NervousText.js](https://github.com/mozilla/rhino/blob/master/examples/src/main/resources/NervousText.js) script is a JavaScript implementation of the famous NervousText applet using JavaScript compiled to Java classes using [jsc](../_tools/javascript_compiler.md). It can be run in the HTML page [NervousText.html](https://github.com/mozilla/rhino/blob/master/examples/src/main/resources/NervousText.html).
 
 ## Controlling the JavaScript Engine
 
 ### The RunScript class
 
-[RunScript.java](https://github.com/mozilla/rhino/tree/master/examples/RunScript.java) is a simple program that executes a script from the command line.
+[RunScript.java](https://github.com/mozilla/rhino/blob/master/examples/src/main/java/RunScript.java) is a simple program that executes a script from the command line.
 
 ### The Control class
 
-[Control.java](https://github.com/mozilla/rhino/tree/master/examples/Control.java) is a program that executes a simple script and then manipulates the result.
+[Control.java](https://github.com/mozilla/rhino/blob/master/examples/src/main/java/Control.java) is a program that executes a simple script and then manipulates the result.
 
 ### JavaScript Shell
 
-[Shell.java](https://github.com/mozilla/rhino/tree/master/examples/Shell.java) is a program that executes JavaScript programs; it is a simplified version of the shell in the `tools` package. The programs may be specified as files on the command line or by typing interactively while the shell is running.
+[Shell.java](https://github.com/mozilla/rhino/blob/master/examples/src/main/java/Shell.java) is a program that executes JavaScript programs; it is a simplified version of the shell in the `tools` package. The programs may be specified as files on the command line or by typing interactively while the shell is running.
 
 ### PrimitiveWrapFactory
 
-[PrimitiveWrapFactory.java](https://github.com/mozilla/rhino/tree/master/examples/PrimitiveWrapFactory.java) is an example of a WrapFactory that can be used to control the wrapping behavior of the Rhino engine on calls to Java methods.
+[PrimitiveWrapFactory.java](https://github.com/mozilla/rhino/blob/master/examples/src/main/java/PrimitiveWrapFactory.java) is an example of a WrapFactory that can be used to control the wrapping behavior of the Rhino engine on calls to Java methods.
 
 ### Multithreaded Script Execution
 
-[DynamicScopes.java](https://github.com/mozilla/rhino/tree/master/examples/DynamicScopes.java) is a program that creates a single global scope object and then shares it across multiple threads. Sharing the global scope allows both information to be shared across threads, and amortizes the cost of Context.initStandardObjects by only performing that expensive operation once.
+[DynamicScopes.java](https://github.com/mozilla/rhino/blob/master/examples/src/main/java/DynamicScopes.java) is a program that creates a single global scope object and then shares it across multiple threads. Sharing the global scope allows both information to be shared across threads, and amortizes the cost of Context.initStandardObjects by only performing that expensive operation once.
 
 ## Implementing Host Objects
 
@@ -58,12 +58,12 @@ First check out the [tutorial](../_tutorials/embedding_tutorial.md) if you haven
 
 ### The Foo class - Extending ScriptableObject
 
-[Foo.java](https://github.com/mozilla/rhino/tree/master/examples/Foo.java) is a simple JavaScript host object that includes a property with an associated action and a variable argument method.
+[Foo.java](https://github.com/mozilla/rhino/blob/master/examples/src/main/java/Foo.java) is a simple JavaScript host object that includes a property with an associated action and a variable argument method.
 
 ### The Matrix class - Implementing Scriptable
 
-[Matrix.java](https://github.com/mozilla/rhino/tree/master/examples/Matrix.java) provides a simple multidimensional array by implementing the Scriptable interface.
+[Matrix.java](https://github.com/mozilla/rhino/blob/master/examples/src/main/java/Matrix.java) provides a simple multidimensional array by implementing the Scriptable interface.
 
 ### The File class - An advanced example
 
-[File.java](https://github.com/mozilla/rhino/tree/master/examples/File.java) extends ScriptableObject to provide a means of reading and writing files from JavaScript. A more involved example of host object definition.
+[File.java](https://github.com/mozilla/rhino/blob/master/examples/src/main/java/File.java) extends ScriptableObject to provide a means of reading and writing files from JavaScript. A more involved example of host object definition.

--- a/docs/_docs/scopes_and_contexts.md
+++ b/docs/_docs/scopes_and_contexts.md
@@ -130,7 +130,7 @@ There's one problem with the setup outlined above. Calls to functions in JavaScr
 
 With Rhino 1.6, it is possible to use _dynamic scope_. With dynamic scope, functions look at the top-level scope of the currently executed script rather than their lexical scope. So we can store information that varies across scopes in the instance scope yet still share functions that manipulate that information reside in the shared scope.
 
-The [DynamicScopes example](https://github.com/mozilla/rhino/examples/DynamicScopes.java) illustrates all the points discussed above.
+The [DynamicScopes example](https://github.com/mozilla/rhino/blob/master/examples/src/main/java/DynamicScopes.java) illustrates all the points discussed above.
 
 ## More on Scopes
 

--- a/docs/_tutorials/embedding_tutorial.md
+++ b/docs/_tutorials/embedding_tutorial.md
@@ -22,7 +22,7 @@ The examples live in the `rhino/examples` directory in the distribution and in `
 
 ## RunScript: A simple embedding
 
-About the simplest embedding of Rhino possible is the [RunScript example](https://github.com/mozilla/rhino/examples/RunScript.java). All it does it read a script from the command line, execute it, and print a result.
+About the simplest embedding of Rhino possible is the [RunScript example](https://github.com/mozilla/rhino/blob/master/examples/src/main/java/RunScript.java). All it does it read a script from the command line, execute it, and print a result.
 
 Here's an example use of RunScript from a shell command line:
 
@@ -129,7 +129,7 @@ hi
 
 ### Adding Java objects
 
-The next example is [RunScript2](https://github.com/mozilla/rhino/examples/RunScript2.java). This is the same as RunScript, but with the addition of two extra lines of code:
+The next example is [RunScript2](https://github.com/mozilla/rhino/blob/master/examples/src/main/java/RunScript2.java). This is the same as RunScript, but with the addition of two extra lines of code:
 
 ```java
 Object wrappedOut = Context.javaToJS(System.out, scope);
@@ -146,7 +146,7 @@ undefined
 
 ## Using JavaScript objects from Java
 
-After evaluating a script it's possible to query the scope for variables and functions, extracting values and calling JavaScript functions. This is illustrated in the [RunScript3](https://github.com/mozilla/rhino/examples/RunScript3.java) example. This example adds the ability to print the value of variable _x_ and the result of calling function `f`. Both _x_ and _f_ are expected to be defined by the evaluated script. For example,
+After evaluating a script it's possible to query the scope for variables and functions, extracting values and calling JavaScript functions. This is illustrated in the [RunScript3](https://github.com/mozilla/rhino/blob/master/examples/src/main/java/RunScript3.java) example. This example adds the ability to print the value of variable _x_ and the result of calling function `f`. Both _x_ and _f_ are expected to be defined by the evaluated script. For example,
 
 ```sh
 $ java RunScript3 "x = 7"
@@ -195,7 +195,7 @@ Custom host objects can implement special JavaScript features like dynamic prope
 
 ### Counter example
 
-The [Counter example](https://mozilla.github.com/rhino/examples/Counter.java) is a simple host object. We'll go through it method by method below.
+The [Counter example](https://github.com/mozilla/rhino/blob/master/examples/src/main/java/Counter.java) is a simple host object. We'll go through it method by method below.
 
 It's easy to try out new host object classes in the shell using its built-in `defineClass` function. We'll see how to add it to RunScript later. (Note that because the `java -jar` option preempts the rest of the classpath, we can't use that and access the `Counter` class.)
 
@@ -270,7 +270,7 @@ The call `c.resetCount()` above calls this method.
 
 ### Adding Counter to RunScript
 
-Now take a look at the [RunScript4 example](https://github.com/mozilla/rhino/examples/RunScript4.java). It's the same as RunScript except for two additions. The method `ScriptableObject.defineClass` uses a Java class to define the Counter "class" in the top-level scope:
+Now take a look at the [RunScript4 example](https://github.com/mozilla/rhino/blob/master/examples/src/main/java/RunScript4.java). It's the same as RunScript except for two additions. The method `ScriptableObject.defineClass` uses a Java class to define the Counter "class" in the top-level scope:
 
 ```java
 ScriptableObject.defineClass(scope, Counter.class);

--- a/docs/_tutorials/scripting_java.md
+++ b/docs/_tutorials/scripting_java.md
@@ -273,7 +273,7 @@ new JavaAdapter(javaIntfOrClass, [javaIntf, ..., javaIntf,] javascriptObject)
 
 Here `javaIntfOrClass` is an interface to implement or a class to extend and `javaIntf` are aditional interfaces to implement. The `javascriptObject` is the JavaScript object containing the methods that will be called from the Java adapter.
 
- See the [enum.js](https://github.com/mozilla/rhino/blob/master/examples/enum.js) example for more information
+ See the [enum.js](https://github.com/mozilla/rhino/blob/master/examples/src/main/resources/enum.js) example for more information
 
 In practice there's little need to call the `JavaAdapter` constructor directly. Most of the time the previous syntaxes using the `new` operator will be sufficient.
 

--- a/docs/license.md
+++ b/docs/license.md
@@ -24,4 +24,4 @@ Few parts of the overall Rhino codebase are distributed under a different licens
 Portions of the floating-point conversion code, and portions of the test suite come from the Google V8 JavaScript engine and are copyrighted by the V8 authors, see [NOTICE.txt](https://github.com/mozilla/rhino/blob/master/NOTICE.txt)
 
 ### License for part of the Rhino Debugger
-The files in [toolsrc/org/mozilla/javascript/tools/debugger/treetable](https://github.com/mozilla/rhino/tree/master/toolsrc/org/mozilla/javascript/tools/debugger/treetable) are copyrighted by Sun Microsystems, Inc., see [NOTICE-tools.txt](https://github.com/mozilla/rhino/blob/master/NOTICE-tools.txt)
+The files in [rhino-tools/src/main/java/org/mozilla/javascript/tools/debugger/treetable](https://github.com/mozilla/rhino/tree/master/rhino-tools/src/main/java/org/mozilla/javascript/tools/debugger/treetable) are copyrighted by Sun Microsystems, Inc., see [NOTICE-tools.txt](https://github.com/mozilla/rhino/blob/master/NOTICE-tools.txt)

--- a/docs/releases/1.5r4_debug_api_changes.md
+++ b/docs/releases/1.5r4_debug_api_changes.md
@@ -188,4 +188,4 @@ class MyDebugFrame implements DebugFrame
 cx.setDebugger(new MyDebugger());
 ```
 Here debugger during execution needs to decide if a particular line has breakpoint on it set or not during script execution, not at the moment of script initialization.
-See also [Rhino Debugger](https://github.com/mozilla/rhino/blob/master/toolsrc/org/mozilla/javascript/tools/debugger/Main.java) that fully explore the new API. The debugger changes includes support for debugging eval and Function scripts and loading script sources from their URL if debugger was not installed during scripts initialization.
+See also [Rhino Debugger](https://github.com/mozilla/rhino/blob/master/rhino-tools/src/main/java/org/mozilla/javascript/tools/debugger/Main.java) that fully explore the new API. The debugger changes includes support for debugging eval and Function scripts and loading script sources from their URL if debugger was not installed during scripts initialization.

--- a/docs/releases/new_in_rhino_1.6r1.md
+++ b/docs/releases/new_in_rhino_1.6r1.md
@@ -18,7 +18,7 @@ nav_order: 7
 ---
 Release Date: 2004-11-29
 
-Rhino 1.6R1 is the new major release of Rhino. It supports ECMAScript for XML (E4X) as specified by [ECMA 357 standard](https://www.ecma-international.org/wp-content/uploads/ECMA-357_2nd_edition_december_2005.pdf). E4X is a set of language extensions adding native XML support for JavaScript without affecting the existing code base. [E4X example](https://github.com/mozilla/rhino/blob/master/examples/E4X/e4x_example.js) demonstrates various E4X constructions and their usage in JavaScript code.
+Rhino 1.6R1 is the new major release of Rhino. It supports ECMAScript for XML (E4X) as specified by [ECMA 357 standard](https://www.ecma-international.org/wp-content/uploads/ECMA-357_2nd_edition_december_2005.pdf). E4X is a set of language extensions adding native XML support for JavaScript without affecting the existing code base. [E4X example](https://github.com/mozilla/rhino/blob/master/examples/src/main/resources/E4X/e4x_example.js) demonstrates various E4X constructions and their usage in JavaScript code.
 
 This version of Rhino should be binary compatible with the current embeddings that use only public [API](https://javadoc.io/doc/org.mozilla/rhino/latestindex.html) unless the code use the previously deprected classes as documented [below](#removal-of-deprecated-classes). Please report any incompatibility issues to Bugzilla.
 
@@ -31,7 +31,7 @@ See [Bugzilla 242805](https://bugzilla.mozilla.org/show_bug.cgi?id=242805) for d
 
 ## Other changes
 ### Common root for Rhino execeptions
-Now all Rhino execption classes are derived from [org.mozilla.javascript.RhinoException](https://github.com/mozilla/rhino/blob/master/src/org/mozilla/javascript/RhinoException.java) which extends `java.lang.RuntimeException`. The class gives the uniform way to access information about the script origin of the exception and simplifies execption handling in Rhino embeddings.
+Now all Rhino execption classes are derived from [org.mozilla.javascript.RhinoException](https://github.com/mozilla/rhino/blob/master/rhino/src/main/java/org/mozilla/javascript/RhinoException.java) which extends `java.lang.RuntimeException`. The class gives the uniform way to access information about the script origin of the exception and simplifies execption handling in Rhino embeddings.
 
 See [Bugzilla 244492](https://bugzilla.mozilla.org/show_bug.cgi?id=244492) for details.
 

--- a/docs/releases/new_in_rhino_1.6r6.md
+++ b/docs/releases/new_in_rhino_1.6r6.md
@@ -69,7 +69,7 @@ Wrapped access to system properties and creation of class loaders into AccessCon
 
 Rhino now comes with test drivers written in Java. These drivers can be used to test Rhino if you are making any changes to the core engine. They are designed to use the tests shared with the C-based SpiderMonkey engine in mozilla/js/tests in CVS.
 
-See [Running the Rhino tests](https://github.com/mozilla/rhino/blob/master/testsrc/README.md) for details on how to execute the tests using JsDriver.
+See [Running the Rhino tests](https://github.com/mozilla/rhino/blob/master/tests/testsrc/README.md) for details on how to execute the tests using JsDriver.
 
 ## Support for calling Java methods and constructors with variable argument lists
 

--- a/docs/releases/new_in_rhino_1.7r2.md
+++ b/docs/releases/new_in_rhino_1.7r2.md
@@ -65,7 +65,7 @@ try {
 ```
 Note also that as an added convenience ContinuationPending supports saving an application-defined object. The continuations API is only supported for interpreted mode.
 
-For more examples of using the API, see the unit test, [ContinuationsAPITest.java](https://github.com/mozilla/rhino/blob/master/testsrc/org/mozilla/javascript/tests/ContinuationsApiTest.java).
+For more examples of using the API, see the unit test, [ContinuationsAPITest.java](https://github.com/mozilla/rhino/blob/master/rhino/src/test/java/org/mozilla/javascript/tests/ContinuationsApiTest.java).
 
 ## Better line editing for Rhino shell
 
@@ -151,4 +151,4 @@ hello, undefined
 
 Now to test this function you might write a  [JUnit](https://www.junit.org/) test that executes a bunch of setup code and then calls `hello()` three times, saving the result value, and calling a comparison function with the actual and expected values. It's a decent amount of code to write.
 
-Doctest does this all for me. Rhino 1.7R2 contains both a new doctest shell function and a JUnit test [DoctestsTest](https://github.com/mozilla/rhino/blob/master/testsrc/org/mozilla/javascript/tests/DoctestsTest.java) that finds files with a `.doctest` extension and runs them. So now all I need to do is copy the shell session above, paste it into `hello.doctest`, and put it in the right directory and I have a JUnit test! It's much more convenient to write tests, which greatly increases the chances that tests actually get written.
+Doctest does this all for me. Rhino 1.7R2 contains both a new doctest shell function and a JUnit test [DoctestsTest](https://github.com/mozilla/rhino/blob/master/tests/src/test/java/org/mozilla/javascript/tests/DoctestsTest.java) that finds files with a `.doctest` extension and runs them. So now all I need to do is copy the shell session above, paste it into `hello.doctest`, and put it in the right directory and I have a JUnit test! It's much more convenient to write tests, which greatly increases the chances that tests actually get written.


### PR DESCRIPTION
Most of these were due to the shuffling around of the source tree to support modules, but it appears that a few of them have been broken longer than that. My editor also added a new line before EOF for a few of the files in which none was present.